### PR TITLE
Delete CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,0 @@
-The Workflows Special Interest Group follows the Conduct of Conduct guidelines outlined by the OpenAPI Initiatives' Technical Steering Committee. Please review [here](https://github.com/OAI/OpenAPI-Specification/blob/main/CODE_OF_CONDUCT.md) 


### PR DESCRIPTION
Ron was able to make the CoC universal across all SIGs so we can erase our specific one.