### PR TITLE
consistent quotes around cookie

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -391,8 +391,8 @@ Describes a single step parameter. A unique parameter is defined by the combinat
 Field Name | Type | Description
 ---|:---:|---
 <a name="parameterName"></a> name | string | **REQUIRED**. The name of the parameter. Parameter names are _case sensitive_.
-<a name="parameterIn"></a> in | string | **REQUIRED**. The name location of the parameter. Possible values are `"path"`, `"query"`, `"header"`, "`cookie`", or `"body"`.
-<a name="parameterStyle"></a> style | string | Describes how the parameter value will be serialized depending on the location of parameter value. This fixed field is predominately used to express how a _request body_ is to be serialized. For example, when request data (`in` with value `"body"`) is to be serialized as `x-www-form-urlencoded`, the style SHOULD be `"form"`. `in` parameters with values of `"query"`, `"header"`, or "`cookie`" MUST derive their style from the referenced `source` when applicable. 
+<a name="parameterIn"></a> in | string | **REQUIRED**. The name location of the parameter. Possible values are `"path"`, `"query"`, `"header"`, `"cookie"`, or `"body"`.
+<a name="parameterStyle"></a> style | string | Describes how the parameter value will be serialized depending on the location of parameter value. This fixed field is predominately used to express how a _request body_ is to be serialized. For example, when request data (`in` with value `"body"`) is to be serialized as `x-www-form-urlencoded`, the style SHOULD be `"form"`. `in` parameters with values of `"query"`, `"header"`, or `"cookie"` MUST derive their style from the referenced `source` when applicable. 
 <a name="parameterTarget"></a> target | {JSON Pointer} | A [JSON Pointer](https://tools.ietf.org/html/rfc6901) expression identifying locations to inject the value. Can be useful for targeting specific request body part.
 <a name="parameterValue"></a> value | Any \| {expression} | **REQUIRED**. The value to pass in the parameter. The value can be a constant or an [expression](#runtime-expressions) to be evaluated and passed to the referenced operation or workflow.
 


### PR DESCRIPTION
Pretty minor nitpick but I wanted `"cookie"` to be consistent with its peers like `"body"` etc.