### PR TITLE
Simplify "Reference Objects `$ref` keywords" to "Reference Objects"

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -93,7 +93,7 @@ In order to preserve the ability to round-trip between YAML and JSON formats, YA
 
 It is RECOMMENDED that the entry Workflows document be named: `workflows.json` or `workflows.yaml`.
 
-A Workflows Description MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [`Reference Objects`](#reference-object) `$ref` keywords are used.  In a multi-document description, the document containing the [Workflows Specification Object](#workflows-specification-object) is known as the **entry Workflows document**.
+A Workflows Description MAY be made up of a single document or be divided into multiple, connected parts at the discretion of the author. In the latter case, [Reference Objects](#reference-object) are used.  In a multi-document description, the document containing the [Workflows Specification Object](#workflows-specification-object) is known as the **entry Workflows document**.
 
 ### Data Types
 


### PR DESCRIPTION
Increases readability, and the referenced section on reference objects defines the `$ref` keyword.

Also make it plain text as "Reference Objects" is not a keyword.