### PR TITLE
Indicate specification is prerelease

### DIFF
--- a/examples/1.0.0/FAPI-PAR.workflow.yaml
+++ b/examples/1.0.0/FAPI-PAR.workflow.yaml
@@ -1,4 +1,4 @@
-workflowsSpec: 1.0.0
+workflowsSpec: 1.0.0-prerelease
 info:
   title: PAR, Authorization and Token workflow
   version: 1.0.0

--- a/examples/1.0.0/LoginAndRetrievePets.workflow.yaml
+++ b/examples/1.0.0/LoginAndRetrievePets.workflow.yaml
@@ -1,4 +1,4 @@
-workflowsSpec: 1.0.0
+workflowsSpec: 1.0.0-prerelease
 info:
     title: A pet purchasing workflow
     summary: This workflow showcases how to purchase a pet through a sequence of API calls

--- a/examples/1.0.0/oauth.workflow.yaml
+++ b/examples/1.0.0/oauth.workflow.yaml
@@ -1,4 +1,4 @@
-workflowsSpec: 1.0.0
+workflowsSpec: 1.0.0-prerelease
 info:
   title: APImetrics OAuth service
   version: 1.0.0

--- a/examples/1.0.0/pet-coupons.workflow.yaml
+++ b/examples/1.0.0/pet-coupons.workflow.yaml
@@ -1,4 +1,4 @@
-workflowsSpec: 1.0.0
+workflowsSpec: 1.0.0-prerelease
 info:
   title: Petstore - Apply Coupons
   version: 1.0.0

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -1,6 +1,8 @@
 # Workflows Specification
 
-## Version 1.0.0
+## Version 1.0.0-prerelease
+
+> _Work is progressing well on this specification. Formally, we are still in a **prerelease** status_
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://tools.ietf.org/html/bcp14) [RFC2119](https://tools.ietf.org/html/rfc2119) [RFC8174](https://tools.ietf.org/html/rfc8174) when, and only when, they appear in all capitals, as shown here.
 
@@ -142,7 +144,7 @@ This object MAY be extended with [Specification Extensions](#specification-exten
 ##### Workflows Specification Object Example
 
 ```yaml
-workflowsSpec: 1.0.0
+workflowsSpec: 1.0.0-prerelease
 info:
   title: A pet purchasing workflow
   summary: This workflow showcases how to purchase a pet through a sequence of API calls
@@ -821,7 +823,7 @@ The proposed MIME media type for Workflows that require a YAML-specific media ty
 
 Version   | Date       | Notes
 ---       | ---        | ---
-1.0.0     | TBD        | First release of the Workflows Specification
+1.0.0     | TBD        | **Not yet released**
 
 
 ## <a name="contextualScopeImage"></a>Appendix B: Contextual scope / access for inputs and outputs

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -18,7 +18,7 @@ The Workflows Specification can articulate these workflows in a human-readable a
 ## Table of Contents
 
 - [Workflows Specification](#workflows-specification)
-  - [Version 1.0.0](#version-100)
+  - [Version 1.0.0-prerelease](#version-100-prerelease)
   - [Introduction](#introduction)
   - [Table of Contents](#table-of-contents)
   - [Definitions](#definitions)


### PR DESCRIPTION
Add clarity that we're not yet officially in a stable `1.0.0` version.

fixes #116