### PR TITLE
Update use of APImetrics name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ The current SIG is made up of the following individuals, and feel free to submit
 
 ### Champions
 
-- David O'Neill ([CEO, APImetrics](https://www.linkedin.com/in/davidon/))
+- David O'Neill ([COO, APIContext](https://www.linkedin.com/in/davidon/))
 - Kin Lane ([Chief Evangelist, Postman](https://www.linkedin.com/in/kinlane/))
 
 ### Contributors
 
-- Nick Denny ([VP Engineering, APImetrics](https://www.linkedin.com/in/nickdenny/))
+- Nick Denny ([Chief Engineer, APIContext](https://www.linkedin.com/in/nickdenny/))
 - Frank Kilcommins ([API Evangelist, SmartBear](https://www.linkedin.com/in/frank-kilcommins))
 - Mike Ralphson ([OpenAPI Specification Lead, Postman](https://www.linkedin.com/in/mikeralphson/))
 - Alessandro Duminuco ([Senior Technical Leader, Cisco](https://www.linkedin.com/in/alessandroduminuco/))

--- a/examples/1.0.0/oauth.openapi.yaml
+++ b/examples/1.0.0/oauth.openapi.yaml
@@ -1,22 +1,22 @@
 openapi: 3.1.0
 info:
-  title: APImetrics OAuth service
+  title: Example OAuth service
   version: 1.0.0
   contact: 
-    email: info@apimetrics.com
+    email: info@example.com
   description: >-
-    APImetrics OAuth service
+    OAuth service
 x-optic-path-ignore:
   - "**/*.+(ico|png|jpeg|jpg|gif)"
 servers:
-  - url: https://auth.apimetrics.io
-    description: APImetrics OAuth Production
+  - url: https://auth.example.com
+    description: Example OAuth Production
 paths:
   /authorize:
     get:
       operationId: authorize
       description: >-
-        This endpoint is used to authorize a user to access the APImetrics API.
+        This endpoint is used to authorize a user to access the Example API.
         The user will be redirected to the login page if they are not already
         logged in. If they are logged in, they will be asked to authorize the
         application to access their account. If they accept, they will be

--- a/examples/1.0.0/oauth.workflow.yaml
+++ b/examples/1.0.0/oauth.workflow.yaml
@@ -1,9 +1,9 @@
 workflowsSpec: 1.0.0-prerelease
 info:
-  title: APImetrics OAuth service
+  title: Example OAuth service
   version: 1.0.0
   description: >-
-    APImetrics OAuth service
+    Example OAuth service
 sourceDescriptions:
   - name: apim-auth
     url: ./oauth.openapi.yaml
@@ -101,7 +101,7 @@ workflows:
         - name: grant_type
           in: body
           style: form
-          value: 'client_credentials'         
+          value: 'client_credentials'
 
         successCriteria:
           - condition: $statusCode == 200
@@ -177,15 +177,15 @@ workflows:
           - name: grant_type
             in: body
             style: form
-            value: 'authorization_code' 
+            value: 'authorization_code'
           - name: redirect_uri
             in: body
             style: form
-            value: $inputs.redirect_uri      
+            value: $inputs.redirect_uri
           - name: code
             in: body
             style: form
-            value: $steps.browser-authorize.outputs.code                     
+            value: $steps.browser-authorize.outputs.code
 
           successCriteria:
             - condition: $statusCode == 200


### PR DESCRIPTION
Thought I'd update these to our new company name while there's still time
- Changed the APImetrics name to APIContext
- Removed the name APImetrics from the OAuth example as it seemed unnecessary