### PR TITLE
Fix the fragments for OAS 3.1 spec references

### DIFF
--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -402,7 +402,7 @@ steps:
 #### Parameter Object
 
 Describes a single step parameter. A unique parameter is defined by the combination of a `name` and `in` fields. There are five possible locations specified by the `in` field:
-  - path - Used together with OpenAPI style [Path Templating](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#pathTemplating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in /items/{itemId}, the path parameter is itemId.
+  - path - Used together with OpenAPI style [Path Templating](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#path-templating), where the parameter value is actually part of the operation's URL. This does not include the host or base path of the API. For example, in /items/{itemId}, the path parameter is itemId.
   - query - Parameters that are appended to the URL. For example, in `/items?id=###`, the query parameter is `id`.
   - header - Custom headers that are expected as part of the request. Note that [RFC7230](https://tools.ietf.org/html/rfc7230#page-22) states header names are case insensitive.
   - cookie - Used to pass a specific cookie value to the source API.
@@ -596,11 +596,11 @@ components:
 
 A simple object to allow referencing other components in the Workflows Description.
 
-**Note -** This section is derived from the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#referenceObject), and is intended to be implemented in similar fashion.
+**Note -** This section is derived from the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object), and is intended to be implemented in similar fashion.
 
 The `$ref` string value contains a URI [RFC3986](https://tools.ietf.org/html/rfc3986), which identifies the location of the value being referenced.
 
-See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relativeReferencesURI).
+See the rules for resolving [Relative References](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#relative-references-in-uris).
 
 ##### Fixed Fields
 Field Name | Type | Description


### PR DESCRIPTION
The camelCase fragments no longer work with GitHub markdown rendering.  Fixes #138 