### PR TITLE
chore: suggest multilevel parameters

### DIFF
--- a/examples/1.0.0/ExtendedParametersExample.workflow.yaml
+++ b/examples/1.0.0/ExtendedParametersExample.workflow.yaml
@@ -1,0 +1,30 @@
+workflowsSpec: 1.0.0
+info:
+  title: Public Zoo API
+  version: '1.0'
+sourceDescriptions:
+  - name: animals
+    type: openapi
+    url: ./animals.yaml
+parameters:
+  - in: header
+    name: Authorization
+    value: Bearer someSecretToken
+workflows:
+  - workflowId: animal-workflow
+    parameters:
+      - in: cookie
+        name: workflowLevelParamOne
+        value: someValue
+      - in: header
+        name: workflowLevelParamTwo
+        value: someValue
+    steps:
+      - stepId: post-step
+        parameters:
+          - in: cookie
+            name: authentication
+            value: SUPER_SECRET
+        operationId: animals.postAnimal
+      - stepId: get-step
+        operationId: animals.getRandomAnimal

--- a/examples/1.0.0/ExtendedParametersExample.workflow.yaml
+++ b/examples/1.0.0/ExtendedParametersExample.workflow.yaml
@@ -6,10 +6,6 @@ sourceDescriptions:
   - name: animals
     type: openapi
     url: ./animals.yaml
-parameters:
-  - in: header
-    name: Authorization
-    value: Bearer someSecretToken
 workflows:
   - workflowId: animal-workflow
     parameters:

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -138,6 +138,7 @@ Field Name | Type | Description
 <a name="workflowsSources"></a>sourceDescriptions | [[Source Description Object](#source-description-object)] | **REQUIRED**. A list of source descriptions (such as an OpenAPI description) this workflow SHALL apply to. The list MUST have at least one entry.
 <a name="workflows"></a>workflows | [[Workflow Object](#workflow-object)] | **REQUIRED**. A list of workflows. The list MUST have at least one entry.
 <a name="components"></a>components | [Components Object](#components-object) | An element to hold various schemas for the Workflows Description.
+<a name="rootParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters to pass to all operations in all workflows.
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 
@@ -273,6 +274,7 @@ Field Name | Type | Description
 <a name="workflowInputs"></a>inputs | `JSON Schema` | A JSON Schema 2020-12 object representing the input parameters used by this workflow.
 <a name="workflowSteps"></a>steps | [[Step Object](#step-object)] | **REQUIRED**. An ordered list of steps where each step represents a call to an API operation or to another workflow.
 <a name="workflowOutputs"></a>outputs | Map[`string`, {expression}] |  A map between a friendly name and a dynamic output value. The name MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
+<a name="workflowParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters to pass to an operation or workflow as referenced by `operationId`, `operationPath`, or `workflowId`. If a Reference Object is provided, it MUST link to parameters defined in [components/parameters](#components-object).
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -273,7 +273,8 @@ Field Name | Type | Description
 <a name="workflowInputs"></a>inputs | `JSON Schema` | A JSON Schema 2020-12 object representing the input parameters used by this workflow.
 <a name="workflowSteps"></a>steps | [[Step Object](#step-object)] | **REQUIRED**. An ordered list of steps where each step represents a call to an API operation or to another workflow.
 <a name="workflowOutputs"></a>outputs | Map[`string`, {expression}] |  A map between a friendly name and a dynamic output value. The name MUST use keys that match the regular expression: `^[a-zA-Z0-9\.\-_]+$`.
-<a name="workflowParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters to pass to an operation or workflow as referenced by `operationId`, `operationPath`, or `workflowId`. If a Reference Object is provided, it MUST link to parameters defined in [components/parameters](#components-object).
+<a name="workflowParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters that are applicable for all steps described under this workflow. These parameters can be overridden at the step level but cannot be removed there. Each parameter MUST be passed to an operation or workflow as referenced by `operationId`, `operationPath`, or `workflowId` as specified within each step. If a Reference Object is provided, it MUST link to parameters defined in [components/parameters](#components-object). The list MUST NOT include duplicate parameters.
+
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 

--- a/versions/1.0.0.md
+++ b/versions/1.0.0.md
@@ -138,7 +138,6 @@ Field Name | Type | Description
 <a name="workflowsSources"></a>sourceDescriptions | [[Source Description Object](#source-description-object)] | **REQUIRED**. A list of source descriptions (such as an OpenAPI description) this workflow SHALL apply to. The list MUST have at least one entry.
 <a name="workflows"></a>workflows | [[Workflow Object](#workflow-object)] | **REQUIRED**. A list of workflows. The list MUST have at least one entry.
 <a name="components"></a>components | [Components Object](#components-object) | An element to hold various schemas for the Workflows Description.
-<a name="rootParameters"></a>parameters | [[Parameter Object](#parameter-object) \| [Reference Object](#reference-object)] | A list of parameters to pass to all operations in all workflows.
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).
 


### PR DESCRIPTION
This pull request proposes the introduction of additional options for defining `parameters` at different levels within the workflow specification. 
According to current suggestion the only level that can have parameters defined is Step level.
This suggestion aims to provide more flexibility by allowing `parameters` definitions at the root and workflow levels as well.

The particular use-case can be found in the `ExtendedParametersExample.workflow.yaml` with JWT authentication token applied to all the Step API calls. This modification eliminates the need for duplicating parameters across individual steps, enhancing overall maintainability.

Same can be applied to `Workflow` level parameters.

```
workflowsSpec: 1.0.0
info:
  title: Public Zoo API
  version: '1.0'
sourceDescriptions:
  - name: animals
    type: openapi
    url: ./animals.yaml
parameters:
  - in: header
    name: Authorization
    value: Bearer someSecretToken
workflows:
  - workflowId: animal-workflow
    parameters:
      - in: cookie
        name: workflowLevelParamOne
        value: someValue
      - in: header
        name: workflowLevelParamTwo
        value: someValue
    steps:
      - stepId: post-step
        parameters:
          - in: cookie
            name: authentication
            value: SUPER_SECRET
        operationId: animals.postAnimal
      - stepId: get-step
        operationId: animals.getRandomAnimal
```

Please let me know what do you think about this idea,
Thanks.