### PR TITLE
fix(schema): remove enumeration in failure action object

### DIFF
--- a/_archive_/schemas/v1.0/schema.yaml
+++ b/_archive_/schemas/v1.0/schema.yaml
@@ -417,7 +417,6 @@ $defs:
             type:
               enum:
                 - goto
-                - retry
         then:
           oneOf:
             - required:

--- a/src/schemas/validation/schema.yaml
+++ b/src/schemas/validation/schema.yaml
@@ -417,7 +417,6 @@ $defs:
             type:
               enum:
                 - goto
-                - retry
         then:
           oneOf:
             - required:


### PR DESCRIPTION
per the spec, the `retry` does not require stepId or workflowId to be strictly defined

fixes #341