### PR TITLE
fix: fix JSONPath specification ambiguity

### DIFF
--- a/src/arazzo.md
+++ b/src/arazzo.md
@@ -706,7 +706,7 @@ Defining this object gives the ability to utilize tooling compatible with older 
 
 | Field Name | Type | Description |
 | --- | :---: | --- |
-| <a name="criterionExpressionType"></a>type | `string` | **REQUIRED**. The type of condition to be applied. The options allowed are `jsonpath` or `xpath`.                                                                                                                             |
+| <a name="criterionExpressionType"></a>type | `string` | **REQUIRED**. The type of condition to be applied. The options allowed are `jsonpath` or `xpath`. |
 | <a name="criterionExpressionVersion"></a>version | `string` | **REQUIRED**. A short hand string representing the version of the expression type being used. The allowed values for JSONPath are `jsonpath-rfc9535`. The allowed values for XPath are `xpath-30`, `xpath-20`, or `xpath-10`. |
 
 This object MAY be extended with [Specification Extensions](#specification-extensions).


### PR DESCRIPTION
I assume the intention was to use RFC9535 everywhere (not the obsoleted draft)?