### PR TITLE
Add missing schema validation fixtures for async, OpenAPI, and workflow steps

### DIFF
--- a/src/arazzo.md
+++ b/src/arazzo.md
@@ -108,10 +108,6 @@ Reference targets include the Arazzo Object's [`$self`](#arazzoSelf) field (when
 
 Implementations MUST NOT treat a reference as unresolvable before completely parsing all documents provided to the implementation as possible parts of the Arazzo Description.
 
-JSON Schema validation alone is not sufficient to prove full Arazzo conformance.
-The Specification is the source of truth, and some constraints require source resolution or other semantic validation across referenced API descriptions and Arazzo documents.
-As a result, a document may be structurally valid according to the published JSON Schema while still being non-compliant if, for example, source typing is inconsistent with step usage or referenced operations/channels cannot be resolved correctly.
-
 #### Fragmentary Parsing
 
 **Fragmentary parsing** occurs when an implementation parses only the specific part of a document being referenced, rather than parsing the complete document first. This practice is **strongly discouraged** and produces undefined behavior.

--- a/src/arazzo.md
+++ b/src/arazzo.md
@@ -108,6 +108,10 @@ Reference targets include the Arazzo Object's [`$self`](#arazzoSelf) field (when
 
 Implementations MUST NOT treat a reference as unresolvable before completely parsing all documents provided to the implementation as possible parts of the Arazzo Description.
 
+JSON Schema validation alone is not sufficient to prove full Arazzo conformance.
+The Specification is the source of truth, and some constraints require source resolution or other semantic validation across referenced API descriptions and Arazzo documents.
+As a result, a document may be structurally valid according to the published JSON Schema while still being non-compliant if, for example, source typing is inconsistent with step usage or referenced operations/channels cannot be resolved correctly.
+
 #### Fragmentary Parsing
 
 **Fragmentary parsing** occurs when an implementation parses only the specific part of a document being referenced, rather than parsing the complete document first. This practice is **strongly discouraged** and produces undefined behavior.

--- a/tests/schema/fail/async-both-operationId-and-channelPath.arazzo.yaml
+++ b/tests/schema/fail/async-both-operationId-and-channelPath.arazzo.yaml
@@ -1,0 +1,15 @@
+arazzo: 1.1.0
+info:
+  title: Async step cannot have both operationId and channelPath
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: sendEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        channelPath: orders
+        action: send

--- a/tests/schema/fail/async-channelPath-without-action.arazzo.yaml
+++ b/tests/schema/fail/async-channelPath-without-action.arazzo.yaml
@@ -1,0 +1,13 @@
+arazzo: 1.1.0
+info:
+  title: Async channelPath step MUST have an action
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: receiveEvent
+        channelPath: orders

--- a/tests/schema/fail/async-depends-on-duplicate-values.arazzo.yaml
+++ b/tests/schema/fail/async-depends-on-duplicate-values.arazzo.yaml
@@ -1,0 +1,20 @@
+arazzo: 1.1.0
+info:
+  title: Async dependsOn should contain unique values
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: sendEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: send
+      - stepId: receiveEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: receive
+        dependsOn:
+          - sendEvent
+          - sendEvent

--- a/tests/schema/fail/async-depends-on-empty.arazzo.yaml
+++ b/tests/schema/fail/async-depends-on-empty.arazzo.yaml
@@ -1,0 +1,18 @@
+arazzo: 1.1.0
+info:
+  title: Async dependsOn must not be empty
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: sendEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: send
+      - stepId: receiveEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: receive
+        dependsOn: []

--- a/tests/schema/fail/async-depends-on-invalid-reference.arazzo.yaml
+++ b/tests/schema/fail/async-depends-on-invalid-reference.arazzo.yaml
@@ -1,0 +1,22 @@
+arazzo: 1.1.0
+info:
+  title: Async dependsOn invalid reference shape
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: sendEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: send
+      - stepId: receiveEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: receive
+        dependsOn:
+          # Invalid on purpose: dependsOn accepts a plain local stepId (`sendEvent`),
+          # `$workflows.<workflowId>.steps.<stepId>`, or
+          # `$sourceDescriptions.<name>.<workflowId>.steps.<stepId>`, but not `$steps.<stepId>`.
+          - $steps.sendEvent

--- a/tests/schema/fail/openapi-both-operationId-and-operationPath.arazzo.yaml
+++ b/tests/schema/fail/openapi-both-operationId-and-operationPath.arazzo.yaml
@@ -1,0 +1,14 @@
+arazzo: 1.1.0
+info:
+  title: OpenAPI step cannot have both operationId and operationPath
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      - stepId: getUsers
+        operationId: $sourceDescriptions.userAPI.listUsers
+        operationPath: $sourceDescriptions.userAPI#/paths/~1users/get

--- a/tests/schema/fail/openapi-duplicate-parameters.arazzo.yaml
+++ b/tests/schema/fail/openapi-duplicate-parameters.arazzo.yaml
@@ -1,0 +1,20 @@
+arazzo: 1.1.0
+info:
+  title: OpenAPI step parameters must be unique
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      - stepId: getUsers
+        operationId: $sourceDescriptions.userAPI.listUsers
+        parameters:
+          - name: limit
+            in: query
+            value: 10
+          - name: limit
+            in: query
+            value: 10

--- a/tests/schema/fail/openapi-missing-operation-target.arazzo.yaml
+++ b/tests/schema/fail/openapi-missing-operation-target.arazzo.yaml
@@ -1,0 +1,12 @@
+arazzo: 1.1.0
+info:
+  title: OpenAPI step must have an operation target
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      - stepId: getUsers

--- a/tests/schema/fail/workflow-duplicate-parameters.arazzo.yaml
+++ b/tests/schema/fail/workflow-duplicate-parameters.arazzo.yaml
@@ -1,0 +1,27 @@
+arazzo: 1.1.0
+info:
+  title: Workflow step parameters must be unique
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      - stepId: nestedWorkflow
+        workflowId: childWorkflow
+        parameters:
+          - name: userId
+            value: 10
+          - name: userId
+            value: 10
+  - workflowId: childWorkflow
+    inputs:
+      type: object
+      properties:
+        userId:
+          type: integer
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers

--- a/tests/schema/fail/workflow-missing-workflowId.arazzo.yaml
+++ b/tests/schema/fail/workflow-missing-workflowId.arazzo.yaml
@@ -1,0 +1,16 @@
+arazzo: 1.1.0
+info:
+  title: Workflow step must include workflowId
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      - stepId: nestedWorkflow
+  - workflowId: childWorkflow
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers

--- a/tests/schema/fail/workflow-step-with-action.arazzo.yaml
+++ b/tests/schema/fail/workflow-step-with-action.arazzo.yaml
@@ -1,0 +1,18 @@
+arazzo: 1.1.0
+info:
+  title: Workflow step cannot have async action
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      - stepId: nestedWorkflow
+        workflowId: childWorkflow
+        action: send
+  - workflowId: childWorkflow
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers

--- a/tests/schema/fail/workflow-step-with-channelPath.arazzo.yaml
+++ b/tests/schema/fail/workflow-step-with-channelPath.arazzo.yaml
@@ -1,0 +1,18 @@
+arazzo: 1.1.0
+info:
+  title: Workflow step cannot have channelPath
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      - stepId: nestedWorkflow
+        workflowId: childWorkflow
+        channelPath: orders
+  - workflowId: childWorkflow
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers

--- a/tests/schema/pass/async-parameter-reusable-reference.arazzo.yaml
+++ b/tests/schema/pass/async-parameter-reusable-reference.arazzo.yaml
@@ -1,0 +1,23 @@
+arazzo: 1.1.0
+info:
+  title: Async step parameter using reusable reference
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+components:
+  parameters:
+    correlationId:
+      name: correlationId
+      in: header
+      value: placeholder
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: sendEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: send
+        parameters:
+          - reference: $components.parameters.correlationId
+            value: abc123

--- a/tests/schema/pass/async-receive-without-correlation-id.arazzo.yaml
+++ b/tests/schema/pass/async-receive-without-correlation-id.arazzo.yaml
@@ -1,0 +1,14 @@
+arazzo: 1.1.0
+info:
+  title: Async receive step does not need a correlationId
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      - stepId: receiveEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated
+        action: receive

--- a/tests/schema/pass/characterization-async-invalid-channelPath-string.arazzo.yaml
+++ b/tests/schema/pass/characterization-async-invalid-channelPath-string.arazzo.yaml
@@ -1,0 +1,16 @@
+arazzo: 1.1.0
+info:
+  title: Characterization of permissive channelPath string validation
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      # Characterization test: this passes today because channelPath is only
+      # validated as a string, not as a resolvable runtime-expression pointer.
+      - stepId: receiveEvent
+        channelPath: definitely-not-a-runtime-expression
+        action: receive

--- a/tests/schema/pass/characterization-asyncapi-operationId-without-action.arazzo.yaml
+++ b/tests/schema/pass/characterization-asyncapi-operationId-without-action.arazzo.yaml
@@ -1,0 +1,15 @@
+arazzo: 1.1.0
+info:
+  title: Characterization of asyncapi operationId without action
+  version: 1.0.0
+sourceDescriptions:
+  - name: eventAPI
+    url: https://events.com/asyncapi.yaml
+    type: asyncapi
+workflows:
+  - workflowId: asyncWorkflow
+    steps:
+      # Characterization test: this passes today because the schema does not
+      # resolve sourceDescriptions.type when selecting the step-object branch.
+      - stepId: sendEvent
+        operationId: $sourceDescriptions.eventAPI.orderCreated

--- a/tests/schema/pass/characterization-openapi-invalid-operationPath-string.arazzo.yaml
+++ b/tests/schema/pass/characterization-openapi-invalid-operationPath-string.arazzo.yaml
@@ -1,0 +1,15 @@
+arazzo: 1.1.0
+info:
+  title: Characterization of permissive operationPath string validation
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      # Characterization test: this passes today because operationPath is only
+      # validated as a string, not as a resolvable runtime-expression pointer.
+      - stepId: getUsers
+        operationPath: definitely-not-a-runtime-expression

--- a/tests/schema/pass/characterization-openapi-operationId-with-action.arazzo.yaml
+++ b/tests/schema/pass/characterization-openapi-operationId-with-action.arazzo.yaml
@@ -1,0 +1,16 @@
+arazzo: 1.1.0
+info:
+  title: Characterization of openapi operationId with async action
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      # Characterization test: this passes today because action makes the step
+      # match the async branch without checking the source type.
+      - stepId: getUsers
+        operationId: $sourceDescriptions.userAPI.listUsers
+        action: send

--- a/tests/schema/pass/characterization-openapi-receive-with-correlationId.arazzo.yaml
+++ b/tests/schema/pass/characterization-openapi-receive-with-correlationId.arazzo.yaml
@@ -1,0 +1,17 @@
+arazzo: 1.1.0
+info:
+  title: Characterization of openapi receive step with correlationId
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      # Characterization test: this passes today because the schema validates
+      # receive/correlation fields structurally without resolving source type.
+      - stepId: getUsers
+        operationId: $sourceDescriptions.userAPI.listUsers
+        action: receive
+        correlationId: request-123

--- a/tests/schema/pass/characterization-workflow-step-with-requestBody.arazzo.yaml
+++ b/tests/schema/pass/characterization-workflow-step-with-requestBody.arazzo.yaml
@@ -1,0 +1,24 @@
+arazzo: 1.1.0
+info:
+  title: Characterization of workflow step with requestBody
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      # Characterization test: this passes today because requestBody is defined
+      # on step-object-base, so workflow steps currently accept it structurally.
+      # This was done to keep backward compatibility.
+      - stepId: nestedWorkflow
+        workflowId: childWorkflow
+        requestBody:
+          contentType: application/json
+          payload:
+            userId: 10
+  - workflowId: childWorkflow
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers

--- a/tests/schema/pass/openapi-operation-path.arazzo.yaml
+++ b/tests/schema/pass/openapi-operation-path.arazzo.yaml
@@ -1,0 +1,13 @@
+arazzo: 1.1.0
+info:
+  title: OpenAPI step with operationPath
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      - stepId: getUsers
+        operationPath: $sourceDescriptions.userAPI#/paths/~1users/get

--- a/tests/schema/pass/openapi-parameter-reusable-reference.arazzo.yaml
+++ b/tests/schema/pass/openapi-parameter-reusable-reference.arazzo.yaml
@@ -1,0 +1,22 @@
+arazzo: 1.1.0
+info:
+  title: OpenAPI step parameter can use reusable reference
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+components:
+  parameters:
+    limit:
+      name: limit
+      in: query
+      value: 10
+workflows:
+  - workflowId: openapiWorkflow
+    steps:
+      - stepId: getUsers
+        operationId: $sourceDescriptions.userAPI.listUsers
+        parameters:
+          - reference: $components.parameters.limit
+            value: 20

--- a/tests/schema/pass/workflow-minimal-step.arazzo.yaml
+++ b/tests/schema/pass/workflow-minimal-step.arazzo.yaml
@@ -1,0 +1,17 @@
+arazzo: 1.1.0
+info:
+  title: Minimal workflow step
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      - stepId: nestedWorkflow
+        workflowId: childWorkflow
+  - workflowId: childWorkflow
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers

--- a/tests/schema/pass/workflow-parameter-reusable-reference.arazzo.yaml
+++ b/tests/schema/pass/workflow-parameter-reusable-reference.arazzo.yaml
@@ -1,0 +1,30 @@
+arazzo: 1.1.0
+info:
+  title: Workflow step parameter using reusable reference
+  version: 1.0.0
+sourceDescriptions:
+  - name: userAPI
+    url: https://users.com/openapi.yaml
+    type: openapi
+components:
+  parameters:
+    userId:
+      name: userId
+      value: 10
+workflows:
+  - workflowId: parentWorkflow
+    steps:
+      - stepId: nestedWorkflow
+        workflowId: childWorkflow
+        parameters:
+          - reference: $components.parameters.userId
+            value: 11
+  - workflowId: childWorkflow
+    inputs:
+      type: object
+      properties:
+        userId:
+          type: integer
+    steps:
+      - stepId: childStep
+        operationId: $sourceDescriptions.userAPI.listUsers


### PR DESCRIPTION
## Summary

Adds fixture coverage for schema validation branches that were already enforced by the Arazzo v1.1 schema but were not explicitly exercised by the test suite.

This PR expands coverage in four areas:

- Async step validation
- OpenAPI step validation
- Workflow step validation
- Characterization of current schema-permitted behavior

## What’s added

### Async fixtures
Adds coverage for:

- `operationId` and `channelPath` mutual exclusivity
- required `action` on async `channelPath` steps
- `dependsOn` empty array rejection
- invalid `dependsOn` reference syntax rejection
- duplicate `dependsOn` entry rejection
- valid `receive` step without `correlationId`
- reusable parameter references on async steps

### OpenAPI fixtures
Adds coverage for:

- valid `operationPath`-only steps
- reusable parameter references on OpenAPI steps
- invalid steps with both `operationId` and `operationPath`
- invalid steps missing both `operationId` and `operationPath`
- duplicate parameter entry rejection

### Workflow step fixtures
Adds coverage for:

- minimal valid workflow steps
- reusable parameter references on workflow steps
- invalid workflow steps missing `workflowId`
- duplicate workflow-step parameter rejection
- rejection of async-only fields like `action` on workflow steps
- rejection of `channelPath` on workflow steps

### Characterization fixtures
Adds pass fixtures that document current validator behavior where structural schema validation succeeds even though deeper semantic validation would still be required:

- `asyncapi` operation step without `action`
- OpenAPI operation step with async `action`
- OpenAPI receive step with `correlationId`
- permissive `operationPath` string handling
- permissive `channelPath` string handling
- workflow step accepting `requestBody`

These are intentional characterization tests for current behavior, not normative conformance examples.

## Notes

For each new negative fixture, I first verified an otherwise-valid baseline and then introduced the single invalidating change. This was done to ensure failures are attributable to the intended schema branch rather than unrelated document-shape issues.

## Validation

- Ran `npm test`
- Result: `62/62` tests passing