### PR TITLE
spec publishing script: create/update minor-version softlink for all versions

### DIFF
--- a/scripts/md2html/build.sh
+++ b/scripts/md2html/build.sh
@@ -71,7 +71,7 @@ for specification in $specifications; do
     fi
   fi
 
-  if [ ${minorVersion} != ${lastMinor} ] && [[ ${minorVersion} =~ ^[3-9] ]]; then
+  if [ ${minorVersion} != ${lastMinor} ]; then
     ln -sf $(basename $destination) $deploydir/v$minorVersion.html
     lastMinor=$minorVersion
   fi


### PR DESCRIPTION
The OAS variant of this script only updates minor-version softlinks for major versions 3 and higher, this restriction is wrong for Arazzo.